### PR TITLE
Automation for Warband-complete quests

### DIFF
--- a/addons/config/locales.lua
+++ b/addons/config/locales.lua
@@ -223,6 +223,8 @@ else
 	L.DeliverTip = 'If enabled, Blitz will deliver any daily or repeatable completed quest.'
 	L.SelectReward = 'Select Reward'
 	L.SelectRewardTip = 'If enabled, Blitz will automatically choose the most valuable reward when delivering quests.'
+    L.Warband = 'Automate If Warband-Complete'
+    L.WarbandTip = 'If enabled, Blitz will automate quests that your other characters have completed.'
 
 	L.Manual = 'Require Key'
 	L.ManualTip = 'If enabled, quests will only be automated if you hold the key below.'

--- a/addons/config/options.lua
+++ b/addons/config/options.lua
@@ -32,6 +32,8 @@ function Options:OnMain()
 		reward.left = reward.left + 20
 		reward:SetSmall(true)
 	end
+	
+	self:AddInput('Check', 'warband', 'Warband')
 
 	self:AddInput('Check', 'manual', 'Manual')
 	self:AddInput('DropChoice', 'key', Blitz.sets.manual and 'AutomateKey' or 'ManualKey'):AddChoices {


### PR DESCRIPTION
Sometimes, you push characters through the same content multiple times. Clicking through the same quest text and occasionally convoluted menus can get irritating, so I made Blitz automate anything one or more characters have completed with a setting.